### PR TITLE
Fix test namespaces

### DIFF
--- a/tests/Algorithms/TravelingSalesman/NearestNeighbourTest.php
+++ b/tests/Algorithms/TravelingSalesman/NearestNeighbourTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Letournel\PathFinder\Tests\Algorithms\ShortestDistance;
+namespace Letournel\PathFinder\Tests\Algorithms\TravelingSalesman;
 
 use Letournel\PathFinder\Algorithms;
 use Letournel\PathFinder\Tests\Algorithms\AbstractTravelingSalesmanTest;

--- a/tests/Algorithms/TravelingSalesman/ThreeOptTest.php
+++ b/tests/Algorithms/TravelingSalesman/ThreeOptTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Letournel\PathFinder\Tests\Algorithms\ShortestDistance;
+namespace Letournel\PathFinder\Tests\Algorithms\TravelingSalesman;
 
 use Letournel\PathFinder\Algorithms;
 use Letournel\PathFinder\Tests\Algorithms\AbstractTravelingSalesmanTest;

--- a/tests/Algorithms/TravelingSalesman/TwoOptTest.php
+++ b/tests/Algorithms/TravelingSalesman/TwoOptTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Letournel\PathFinder\Tests\Algorithms\ShortestDistance;
+namespace Letournel\PathFinder\Tests\Algorithms\TravelingSalesman;
 
 use Letournel\PathFinder\Algorithms;
 use Letournel\PathFinder\Tests\Algorithms\AbstractTravelingSalesmanTest;


### PR DESCRIPTION
Change TravelingSalesman test namespaces to comply with psr-4 autoloading standard